### PR TITLE
acseo_typesense.yml : l48 TYPESENSE_URL => DATABASE_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ acseo_typesense:
     # Typesense host settings
     typesense:
         host: '%env(resolve:TYPESENSE_URL)%'
-        key: '%env(resolve:TYPESENSE_URL)%'
+        key: '%env(resolve:DATABASE_KEY)%'
     # Collection settings
     collections:
         books:                                     # Typesense collection name


### PR DESCRIPTION
I think in acseo_typesense.yml example, copy and paste was made too fast. 