### PR TITLE
Use array_values to reset keys on collection field

### DIFF
--- a/src/Transformer/DoctrineToTypesenseTransformer.php
+++ b/src/Transformer/DoctrineToTypesenseTransformer.php
@@ -85,9 +85,9 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
             case self::TYPE_OBJECT.self::TYPE_STRING:
                 return $value->__toString();
             case self::TYPE_COLLECTION.self::TYPE_ARRAY_STRING:
-                return $value->map(function ($v) {
+                return array_values($value->map(function ($v) {
                     return $v->__toString();
-                })->toArray();
+                })->toArray());
             case self::TYPE_STRING.self::TYPE_STRING:
                 return (string) $value;
             default:


### PR DESCRIPTION
Hi !

I'm faced to an issue on collection fields.

During transformation, the method ` $collection->map()` preserves the keys of items in the collection.
If the method `$collection->removeElement(...)` was called before, the element key has been deleted and collection keys won't be reindexed. In this example, as the keys of result array are not a numerical sequence, it will be encoded to an object, but Typesense expects an array.

This PR purposes a simple fix by calling the method array_values on the result array of "map" method to reset array keys.

Thanks !

