### PR TITLE
Use Symfony property accessor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
             "name": "Nicolas Potier",
             "email": "nicolas.potier@acseo.fr"
         }
-    ],    
+    ],
     "require": {
         "php": "^7.4||^8.0",
         "doctrine/orm": "~2.8,>=2.8.0",
@@ -16,7 +16,8 @@
         "symfony/http-client-contracts": "^1.0|^2.0",
         "typesense/typesense-php": "^4.1.0",
         "php-http/curl-client": "^2.2",
-        "monolog/monolog": "^2.3"
+        "monolog/monolog": "^2.3",
+        "symfony/property-access": "^3.4|^4.3|^5"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0",

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -63,6 +63,7 @@
         <service id="typesense.transformer.doctrine_to_typesense"
                  class="ACSEO\TypesenseBundle\Transformer\DoctrineToTypesenseTransformer">
             <argument/> <!-- collections -->
+            <argument type="service" id="property_accessor" />
         </service>
 
         <!-- commands -->

--- a/src/Transformer/DoctrineToTypesenseTransformer.php
+++ b/src/Transformer/DoctrineToTypesenseTransformer.php
@@ -26,7 +26,7 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
     {
         $entityClass = ClassUtils::getClass($entity);
 
-        if (!isset($this->$entityToCollectionMapping[$entityClass])) {
+        if (!isset($this->entityToCollectionMapping[$entityClass])) {
             throw new \Exception(sprintf('Class %s is not supported for Doctrine To Typesense Transformation', $entityClass));
         }
 
@@ -38,7 +38,7 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
             $data[$typesenseField] = $this->castValue(
                 $entityClass,
                 $typesenseField,
-                $this->accessor->getValue($entity, $fieldsInfo['name'])
+                $this->accessor->getValue($entity, $fieldsInfo['entity_attribute'])
             );
         }
 

--- a/src/Transformer/DoctrineToTypesenseTransformer.php
+++ b/src/Transformer/DoctrineToTypesenseTransformer.php
@@ -3,6 +3,7 @@
 namespace ACSEO\TypesenseBundle\Transformer;
 
 use Doctrine\Common\Util\ClassUtils;
+use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 class DoctrineToTypesenseTransformer extends AbstractTransformer
@@ -14,7 +15,7 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
     public function __construct(array $collectionDefinitions, PropertyAccessorInterface $accessor)
     {
         $this->collectionDefinitions = $collectionDefinitions;
-        $this->accessor = $accessor;
+        $this->accessor              = $accessor;
 
         $this->entityToCollectionMapping = [];
         foreach ($this->collectionDefinitions as $collection => $collectionDefinition) {
@@ -27,7 +28,9 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
         $entityClass = ClassUtils::getClass($entity);
 
         if (!isset($this->entityToCollectionMapping[$entityClass])) {
-            throw new \Exception(sprintf('Class %s is not supported for Doctrine To Typesense Transformation', $entityClass));
+            throw new \Exception(
+                sprintf('Class %s is not supported for Doctrine To Typesense Transformation', $entityClass)
+            );
         }
 
         $data = [];
@@ -35,10 +38,16 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
         $fields = $this->collectionDefinitions[$this->entityToCollectionMapping[$entityClass]]['fields'];
 
         foreach ($fields as $typesenseField => $fieldsInfo) {
+            try {
+                $value = $this->accessor->getValue($entity, $fieldsInfo['entity_attribute']);
+            } catch (UnexpectedTypeException $exception) {
+                $value = null;
+            }
+
             $data[$typesenseField] = $this->castValue(
                 $entityClass,
                 $typesenseField,
-                $this->accessor->getValue($entity, $fieldsInfo['entity_attribute'])
+                $value
             );
         }
 
@@ -47,15 +56,18 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
 
     public function castValue($entityClass, $name, $value)
     {
-        $collection = $this->entityToCollectionMapping[$entityClass];
-        $key = array_search($name, array_column(
-            $this->collectionDefinitions[$collection]['fields'],
-            'name'
-        ));
+        $collection                  = $this->entityToCollectionMapping[$entityClass];
+        $key                         = array_search(
+            $name,
+            array_column(
+                $this->collectionDefinitions[$collection]['fields'],
+                'name'
+            )
+        );
         $collectionFieldsDefinitions = array_values($this->collectionDefinitions[$collection]['fields']);
 
         $originalType = $collectionFieldsDefinitions[$key]['type'];
-        $castedType = $this->castType($originalType);
+        $castedType   = $this->castType($originalType);
 
         switch ($originalType.$castedType) {
             case self::TYPE_DATETIME.self::TYPE_INT_64:
@@ -67,12 +79,14 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
             case self::TYPE_OBJECT.self::TYPE_STRING:
                 return $value->__toString();
             case self::TYPE_COLLECTION.self::TYPE_ARRAY_STRING:
-                return array_values($value->map(function ($v) {
-                    return $v->__toString();
-                })->toArray());
+                return array_values(
+                    $value->map(function ($v) {
+                        return $v->__toString();
+                    })->toArray()
+                );
             case self::TYPE_STRING.self::TYPE_STRING:
             case self::TYPE_PRIMARY.self::TYPE_STRING:
-                return (string) $value;
+                return (string)$value;
             default:
                 return $value;
         }


### PR DESCRIPTION
Allow to use more complex fields `entity_attributes` and simplify the code.
Examples: `address[0].city` or `translations[0].name`