### PR TITLE
Index documents only on postFlush event

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -57,6 +57,8 @@
             <tag name="doctrine.event_listener" event="postPersist" priority="500" connection="default"/>
             <tag name="doctrine.event_listener" event="postUpdate" priority="500" connection="default"/>
             <tag name="doctrine.event_listener" event="preRemove" priority="500" connection="default"/>
+            <tag name="doctrine.event_listener" event="postRemove" priority="500" connection="default"/>
+            <tag name="doctrine.event_listener" event="postFlush" priority="500" connection="default"/>
         </service>
 
         <service id="typesense.transformer.doctrine_to_typesense"


### PR DESCRIPTION
Since doctrine uses transactions to roll back all queries in case of error, indexing operations should be run only on postFlush event.