### PR TITLE
Fix typo in method name.

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -36,7 +36,7 @@ class CreateCommand extends Command
         foreach ($defs as $name => $def) {
             try {
                 $output->writeln(sprintf('<info>Deleting</info> <comment>%s</comment>', $name));
-                $this->collectionManager->deleteCollextion($name);
+                $this->collectionManager->deleteCollection($name);
             } catch (\Typesense\Exceptions\ObjectNotFound $exception) {
                 $output->writeln(sprintf('<comment>%s</comment> <info>does not exists</info> ', $name));
             }

--- a/src/Manager/CollectionManager.php
+++ b/src/Manager/CollectionManager.php
@@ -47,10 +47,15 @@ class CollectionManager
         }
     }
 
-    public function deleteCollextion($collectionDefinitionName)
+    public function deleteCollection($collectionDefinitionName)
     {
         $definition = $this->collectionDefinitions[$collectionDefinitionName];
         $this->collectionClient->delete($definition['typesense_name']);
+    }
+
+    public function deleteCollextion($collectionDefinitionName)
+    {
+        return $this->deleteCollection($collectionDefinitionName);
     }
 
     public function createCollection($collectionDefinitionName)


### PR DESCRIPTION
Just for the beauty 🙂 

I kept the previous method, because it's part of the public interface and may be used by someone out there. 