### PR TITLE
Allow "collection_name" parameter.

### DIFF
--- a/src/DependencyInjection/ACSEOTypesenseExtension.php
+++ b/src/DependencyInjection/ACSEOTypesenseExtension.php
@@ -84,6 +84,7 @@ class ACSEOTypesenseExtension extends Extension
     {
         foreach ($collections as $name => $config) {
             $collectionName = $config['collection_name'] ?? $name;
+            $collectionName = $container->resolveEnvPlaceholders($collectionName, true);
 
             $primaryKeyExists = false;
 
@@ -112,8 +113,8 @@ class ACSEOTypesenseExtension extends Extension
 
             if (isset($config['finders'])) {
                 foreach ($config['finders'] as $finderName => $finderConfig) {
-                    $finderName                      = $collectionName.'.'.$finderName;
-                    $finderConfig['collection_name'] = $collectionName;
+                    $finderName                      = $name.'.'.$finderName;
+                    $finderConfig['collection_name'] = $name;
                     $finderConfig['finder_name']     = $finderName;
                     if (!isset($finderConfig['finder_parameters']['query_by'])) {
                         throw new \Exception('acseo_typesense.collections.'.$finderName.'.finder_parameters.query_by must be set');
@@ -158,9 +159,7 @@ class ACSEOTypesenseExtension extends Extension
     private function loadCollectionsFinder(ContainerBuilder $container)
     {
         foreach ($this->collectionsConfig as $name => $config) {
-            $collectionName = $config['typesense_name'];
-
-            $finderId  = sprintf('typesense.finder.%s', $collectionName);
+            $finderId  = sprintf('typesense.finder.%s', $name);
             $finderDef = new ChildDefinition('typesense.finder');
             $finderDef->replaceArgument(2, $config);
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -29,6 +29,7 @@ class Configuration implements ConfigurationInterface
                     ->arrayPrototype()
                         ->children()
                             ->scalarNode('entity')->end()
+                            ->scalarNode('collection_name')->end()
                             ->arrayNode('fields')
                                 ->arrayPrototype()
                                     ->children()


### PR DESCRIPTION
Hi, 

I'm running multiple instances of the same webapp against a unique Typesense server, and I'm using namespaces/prefixes for collection names. For example let's say I have a `products` collection, there would be collections prefixed by the app name (`app_A_products`, `app_B_products`, etc). Also, on my dev environment, I have a specific collection for tests (i.e `app_products_test`). 

All of this is made dynamic by using env vars. 

Of course, I would like to use the "generic" name (i.e `products`) inside my code, while having TypesenseBundle classes target the expected collection. 

---

I noticed there is a [`collection_name` parameter](https://github.com/acseo/TypesenseBundle/blob/e44574e6f10269988d05cd27d1b46bde5d94fe52/src/DependencyInjection/ACSEOTypesenseExtension.php#L86) which seems designed for this, but is unused. So I tried to make it work. 
Not sure what I did is 100% correct as I'm not an expert in Symfony dependency injection. 

As a result, with the following configuration: 

```yaml
parameters:
    env(APP_NAME): "app_A"
    typesense_products_collection_name: "%env(APP_NAME)%_products"

acseo_typesense:
    collections:
        products:
            collection_name: '%typesense_products_collection_name%'
            entity: 'App\Entity\Product'
            fields:
                id:
                    name: id
                    type: primary
                sortable_id:
                    entity_attribute: id
                    name: sortable_id
                    type: int32
                name:
                    name: name
                    type: string
            default_sorting_field: sortable_id
```

- When calling `$collectionManager->createCollection('products')` (for example), it actually creates the `app_A_products` collection
- I have a service `typesense.finder.products` which actually targets the collection `app_A_products`

Related to #22