### PR TITLE
add monolog version 3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/http-client-contracts": "^1.0|^2.0|^3.0",
         "typesense/typesense-php": "^4.1.0",
         "php-http/curl-client": "^2.2",
-        "monolog/monolog": "^2.3",
+        "monolog/monolog": "^2.3|^3.0",
         "symfony/property-access": "^3.4|^4.3|^5|^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
Hi everyone,

I've added  `monolog/monolog:^3.0` because the bundle was not installable on a Symfony 6.1 project.

Hope it helps