### PR TITLE
Update DoctrineToTypesenseTransformer.php

### DIFF
--- a/src/Transformer/DoctrineToTypesenseTransformer.php
+++ b/src/Transformer/DoctrineToTypesenseTransformer.php
@@ -72,7 +72,7 @@ class DoctrineToTypesenseTransformer extends AbstractTransformer
 
         switch ($originalType.$castedType) {
             case self::TYPE_DATETIME.self::TYPE_INT_64:
-                if ($value instanceof \DateTime) {
+                if ($value instanceof \DateTimeInterface) {
                     return $value->getTimestamp();
                 }
 


### PR DESCRIPTION
Only `DateTime` object is checked.
`DateTimeImmutable` isn't

It's better to check the interface instead of the class.