### PR TITLE
Fix TypesenseIndexer when using collection_prefix / collection_name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0|^6.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/yaml": "^3.4 || ^4.4 || ^5.4 || ^6.0"
+        "symfony/yaml": "^3.4 || ^4.4 || ^5.4 || ^6.0",
+        "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
         "psr-4": { "ACSEO\\TypesenseBundle\\": "src/" }

--- a/src/EventListener/TypesenseIndexer.php
+++ b/src/EventListener/TypesenseIndexer.php
@@ -56,7 +56,7 @@ class TypesenseIndexer
             return;
         }
 
-        $collectionDefinitionKey = $this->getCollectionName($entity);
+        $collectionDefinitionKey = $this->getCollectionKey($entity);
         $collectionConfig        = $this->collectionManager->getCollectionDefinitions()[$collectionDefinitionKey];
 
         $this->checkPrimaryKeyExists($collectionConfig);
@@ -156,5 +156,16 @@ class TypesenseIndexer
         $entityClassname = ClassUtils::getClass($entity);
 
         return array_search($entityClassname, $this->managedClassNames, true);
+    }
+
+    private function getCollectionKey($entity)
+    {
+        $entityClassname = ClassUtils::getClass($entity);
+
+        foreach ($this->collectionManager->getCollectionDefinitions() as $key => $def) {
+            if ($def['entity'] === $entityClassname) {
+                return $key;
+            }
+        }
     }
 }

--- a/tests/Unit/EventListener/TypesenseIndexerTest.php
+++ b/tests/Unit/EventListener/TypesenseIndexerTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ACSEO\Bundle\TypesenseBundle\Tests\Unit\EventListener;
+
+use ACSEO\TypesenseBundle\Client\CollectionClient;
+use ACSEO\TypesenseBundle\Manager\DocumentManager;
+use ACSEO\TypesenseBundle\EventListener\TypesenseIndexer;
+use ACSEO\TypesenseBundle\Manager\CollectionManager;
+use ACSEO\TypesenseBundle\Tests\Functional\Entity\Book;
+use ACSEO\TypesenseBundle\Tests\Functional\Entity\Author;
+use ACSEO\TypesenseBundle\Transformer\DoctrineToTypesenseTransformer;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\PropertyAccess\PropertyAccess;
+
+class TypesenseIndexerTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function setUp(): void
+    {
+        $this->objectManager = $this->prophesize(ObjectManager::class);
+        $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+    }
+
+    private function initialize($collectionDefinitions)
+    {
+        $transformer = new DoctrineToTypesenseTransformer($collectionDefinitions, $this->propertyAccessor);
+
+        $collectionClient = $this->prophesize(CollectionClient::class);
+
+        $collectionManager = new CollectionManager($collectionClient->reveal(), $transformer, $collectionDefinitions);
+        $this->documentManager = $this->prophesize(DocumentManager::class);
+
+        $this->eventListener = new TypesenseIndexer($collectionManager, $this->documentManager->reveal(), $transformer);
+    }
+
+    /**
+     * @dataProvider postUpdateProvider
+     */
+    public function testPostUpdate($prefix)
+    {
+        $collectionDefinitions = $this->getCollectionDefinitions(Book::class, $prefix);
+
+        $this->initialize($collectionDefinitions);
+
+        $book = new Book(1, 'The Doors of Perception', new Author('Aldoux Huxley', 'United Kingdom'), new \DateTime('1954-01-01'));
+
+        $eventArgs = new LifecycleEventArgs($book, $this->objectManager->reveal());
+
+        $this->eventListener->postUpdate($eventArgs);
+        $this->eventListener->postFlush();
+
+        $this->documentManager->delete(sprintf('%sbooks', $prefix), 1)->shouldHaveBeenCalled();
+        $this->documentManager->index(sprintf('%sbooks', $prefix), [
+            'id' => 1,
+            'sortable_id' => 1,
+            'title' => 'The Doors of Perception',
+            'author' => 'Aldoux Huxley',
+            'author_country' => 'United Kingdom',
+            'published_at' => -504921600,
+        ])->shouldHaveBeenCalled();
+    }
+
+    public function postUpdateProvider()
+    {
+        return [
+            [ '' ],
+            [ 'foo_' ],
+        ];
+    }
+
+    private function getCollectionDefinitions($entityClass, $prefix = '')
+    {
+        return [
+            'books' => [
+                'typesense_name' => sprintf('%sbooks', $prefix),
+                'entity'         => $entityClass,
+                'name'           => 'books',
+                'fields'         => [
+                    'id' => [
+                        'name'             => 'id',
+                        'type'             => 'primary',
+                        'entity_attribute' => 'id',
+                    ],
+                    'sortable_id' => [
+                        'entity_attribute' => 'id',
+                        'name'             => 'sortable_id',
+                        'type'             => 'int32',
+                    ],
+                    'title' => [
+                        'name'             => 'title',
+                        'type'             => 'string',
+                        'entity_attribute' => 'title',
+                    ],
+                    'author' => [
+                        'name'             => 'author',
+                        'type'             => 'object',
+                        'entity_attribute' => 'author',
+                    ],
+                    'michel' => [
+                        'name'             => 'author_country',
+                        'type'             => 'string',
+                        'entity_attribute' => 'author.country',
+                    ],
+                    'publishedAt' => [
+                        'name'             => 'published_at',
+                        'type'             => 'datetime',
+                        'optional'         => true,
+                        'entity_attribute' => 'publishedAt',
+                    ],
+                ],
+                'default_sorting_field' => 'sortable_id',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Hi, 

This follows the changes introduced in #65

When using `collection_prefix` and/or `collection_name`, the array returned by `CollectionManager::getCollectionDefinitions()` is indexed by the "unprefixed" key. 

For example, when using `collection_prefix: foo` & `collection_name: shops_test`, we have the following error:

```
Warning: Undefined array key "foo_shops_test" in vendor/acseo/typesense-bundle/src/EventListener/TypesenseIndexer.php line 63
```

---

Moreover, I'm wondering if `checkPrimaryKeyExists` is actually needed. There is some code in `ACSEOTypesenseExtension` that seems to create a primary key automatically. 

https://github.com/acseo/TypesenseBundle/blob/68686225556d709e975ab164f16dfeda04b5ac07/src/DependencyInjection/ACSEOTypesenseExtension.php#L115-L120

