### PR TITLE
Allow to call a method from a service instead of a getter

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -65,6 +65,7 @@
                  class="ACSEO\TypesenseBundle\Transformer\DoctrineToTypesenseTransformer">
             <argument/> <!-- collections -->
             <argument type="service" id="property_accessor" />
+            <argument type="service" id="service_container" />
         </service>
 
         <!-- commands -->

--- a/tests/Functional/AllowNullConnexionTest.php
+++ b/tests/Functional/AllowNullConnexionTest.php
@@ -22,6 +22,7 @@ use Doctrine\ORM\EntityManager;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -95,7 +96,8 @@ class AllowNullConnexionTest extends KernelTestCase
         $typeSenseClient       = new TypesenseClient('null', 'null');
         $propertyAccessor      = PropertyAccess::createPropertyAccessor();
         $collectionClient      = new CollectionClient($typeSenseClient);
-        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor);
+        $container             = $this->createMock(ContainerInterface::class);
+        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor, $container);
         $collectionManager     = new CollectionManager($collectionClient, $transformer, $collectionDefinitions);
 
         $command = new CreateCommand($collectionManager);
@@ -117,7 +119,8 @@ class AllowNullConnexionTest extends KernelTestCase
         $typeSenseClient       = new TypesenseClient('null', 'null');
         $propertyAccessor      = PropertyAccess::createPropertyAccessor();
         $collectionClient      = new CollectionClient($typeSenseClient);
-        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor);
+        $container             = $this->createMock(ContainerInterface::class);
+        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor, $container);
         $documentManager       = new DocumentManager($typeSenseClient);
         $collectionManager     = new CollectionManager($collectionClient, $transformer, $collectionDefinitions);
         $em                    = $this->getMockedEntityManager($books);

--- a/tests/Functional/Service/BookConverter.php
+++ b/tests/Functional/Service/BookConverter.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ACSEO\TypesenseBundle\Tests\Functional\Service;
+
+class BookConverter
+{
+    /**
+     * In a real life example maybe you would need to call some extra service to get this URL
+     * and that service can be injected with DI into this one
+     */
+    public function getCoverImageURL($book) : string
+    {
+        return sprintf('http://fake.image/%d', $book->getId());
+    }
+}

--- a/tests/Functional/TypesenseInteractionsTest.php
+++ b/tests/Functional/TypesenseInteractionsTest.php
@@ -24,6 +24,7 @@ use Doctrine\ORM\Event\LifecycleEventArgs;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
@@ -172,7 +173,8 @@ class TypesenseInteractionsTest extends KernelTestCase
         $collectionClient      = new CollectionClient($typeSenseClient);
         $collectionDefinitions = $this->getCollectionDefinitions(Book::class);
         $propertyAccessor      = PropertyAccess::createPropertyAccessor();
-        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor);
+        $container             = $this->createMock(ContainerInterface::class);
+        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor, $container);
         $collectionManager     = new CollectionManager($collectionClient, $transformer, $collectionDefinitions);
         $typeSenseClient       = new TypesenseClient($_ENV['TYPESENSE_URL'], $_ENV['TYPESENSE_KEY']);
         $documentManager       = new DocumentManager($typeSenseClient);
@@ -244,7 +246,8 @@ class TypesenseInteractionsTest extends KernelTestCase
         $typeSenseClient       = new TypesenseClient($_ENV['TYPESENSE_URL'], $_ENV['TYPESENSE_KEY']);
         $propertyAccessor      = PropertyAccess::createPropertyAccessor();
         $collectionClient      = new CollectionClient($typeSenseClient);
-        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor);
+        $container             = $this->createMock(ContainerInterface::class);
+        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor, $container);
         $collectionManager     = new CollectionManager($collectionClient, $transformer, $collectionDefinitions);
 
         $command = new CreateCommand($collectionManager);
@@ -266,7 +269,8 @@ class TypesenseInteractionsTest extends KernelTestCase
         $typeSenseClient       = new TypesenseClient($_ENV['TYPESENSE_URL'], $_ENV['TYPESENSE_KEY']);
         $propertyAccessor      = PropertyAccess::createPropertyAccessor();
         $collectionClient      = new CollectionClient($typeSenseClient);
-        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor);
+        $container             = $this->createMock(ContainerInterface::class);
+        $transformer           = new DoctrineToTypesenseTransformer($collectionDefinitions, $propertyAccessor, $container);
         $documentManager       = new DocumentManager($typeSenseClient);
         $collectionManager     = new CollectionManager($collectionClient, $transformer, $collectionDefinitions);
         $em                    = $this->getMockedEntityManager($books, $options);

--- a/tests/Unit/EventListener/TypesenseIndexerTest.php
+++ b/tests/Unit/EventListener/TypesenseIndexerTest.php
@@ -15,6 +15,7 @@ use Doctrine\Persistence\Event\LifecycleEventArgs;
 use Doctrine\Persistence\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class TypesenseIndexerTest extends TestCase
@@ -25,11 +26,12 @@ class TypesenseIndexerTest extends TestCase
     {
         $this->objectManager = $this->prophesize(ObjectManager::class);
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
+        $this->container = $this->prophesize(ContainerInterface::class);
     }
 
     private function initialize($collectionDefinitions)
     {
-        $transformer = new DoctrineToTypesenseTransformer($collectionDefinitions, $this->propertyAccessor);
+        $transformer = new DoctrineToTypesenseTransformer($collectionDefinitions, $this->propertyAccessor, $this->container->reveal());
 
         $collectionClient = $this->prophesize(CollectionClient::class);
 


### PR DESCRIPTION
Hi, 

In our project for some entity fields we need to use services to get the value instead of just a getter.

In order to be able to do that, we thought of this functionality with which now we can configure a field to obtain its value from a service. An example configuration would be:
```
fields:
    conver_image_url:
        entity_attribute: 'AppBundle\Typesense\Converter\BookConverter::getCoverImageURL'
        name: cover_image_url
        type: string
```

And then the class would accept the entity as parameter and could has some service injected to get the value:
```
class BookConverter 
{
    public function __construct(SomeExtraService $extraService)
    {
        $this->extraService = $extraService;
    }

    public function getCoverImageURL($book): string
    {
        // Use injected service to generate image URL
    }
}
```
