### PR TITLE
Keep compatibility with Doctrine 2.x.x

### DIFF
--- a/src/Command/ImportCommand.php
+++ b/src/Command/ImportCommand.php
@@ -67,10 +67,16 @@ class ImportCommand extends Command
 
         $action = $input->getOption('action');
 
-        $this->em->getConnection()->getConfiguration()->setMiddlewares(
-            [new \Doctrine\DBAL\Logging\Middleware(new \Psr\Log\NullLogger())]
-        );
-        
+        // 'setMiddlewares' method only exists for Doctrine version >=3.0.0
+        if (method_exists($this->em->getConnection()->getConfiguration(), 'setMiddlewares')) {
+            $this->em->getConnection()->getConfiguration()->setMiddlewares(
+                [new \Doctrine\DBAL\Logging\Middleware(new \Psr\Log\NullLogger())]
+            );
+        } else {
+            // keep compatibility with versions 2.x.x of Doctrine
+            $this->em->getConnection()->getConfiguration()->setSQLLogger(null);
+        }
+
         $execStart = microtime(true);
         $populated = 0;
 


### PR DESCRIPTION
Fixes #77 

'setMiddlewares' method only exists for Doctrine version >=3.0.0.

Since 'setSQLLogger' is deprecated but [still available until Doctrine 3.6.x](https://github.com/doctrine/dbal/blob/e4564fb046b2dc5072d7dd05049913a00974ce9c/src/Configuration.php#L73) I think would be better to keep compatibility using this method for lower versions of Doctrine.