### PR TITLE
Fix Entity Hydration Issue for Inherited Entities with DiscriminatorMap

### DIFF
--- a/src/Finder/CollectionFinder.php
+++ b/src/Finder/CollectionFinder.php
@@ -43,11 +43,30 @@ class CollectionFinder implements CollectionFinderInterface
 
         $hydratedResults = [];
         if (count($ids)) {
-            $rsm = new ResultSetMappingBuilder($this->em);
-            $rsm->addRootEntityFromClassMetadata($this->collectionConfig['entity'], 'e');
-            $tableName       = $this->em->getClassMetadata($this->collectionConfig['entity'])->getTableName();
-            $query           = $this->em->createNativeQuery('SELECT * FROM '.$tableName.' WHERE '.$primaryKeyInfos['entityAttribute'].' IN ('.implode(', ', $ids).') ORDER BY FIELD(id,'.implode(', ', $ids).')', $rsm);
-            $hydratedResults = $query->getResult();
+            $dql = sprintf(
+                'SELECT e FROM %s e WHERE e.%s IN (:ids)',
+                $this->collectionConfig['entity'],
+                $primaryKeyInfos['entityAttribute']
+            );
+
+            $query = $this->em->createQuery($dql);
+            $query->setParameter('ids', $ids);
+
+            $unorderedResults = $query->getResult();
+
+            // sort index
+            $idIndex = array_flip($ids);
+
+            usort($unorderedResults, function ($a, $b) use ($idIndex, $primaryKeyInfos) {
+                $entityIdMethod = 'get' . ucfirst($primaryKeyInfos['entityAttribute']);
+                $idA = $a->$entityIdMethod();
+                $idB = $b->$entityIdMethod();
+
+                return $idIndex[$idA] <=> $idIndex[$idB];
+            });
+
+            $hydratedResults = $unorderedResults;
+
         }
         $results->setHydratedHits($hydratedResults);
         $results->setHydrated(true);


### PR DESCRIPTION
### Problem Description
In the existing system, the hydration of entities resulting from a search query is not geared towards entity hierarchies that have a DiscriminatorMap. This leads to a "ResultSetMapping builder does not currently support your inheritance scheme" error when attempting to use ResultSetMappingBuilder with entities that have an inheritance hierarchy.

### Proposed Solution
Instead of relying on a native SQL query and ResultSetMappingBuilder, this PR employs DQL to fetch the entities, which natively supports DiscriminatorMap. After fetching the entities using DQL, we use usort in PHP to sort them in the desired order. This allows us to circumvent the aforementioned error while retaining the ability to sort the entities.

This also likely fixes Issue #87 as we no longer use the FIELD function in our queries.