### PR TITLE
allow user to recreate only one index

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -7,7 +7,9 @@ namespace ACSEO\TypesenseBundle\Command;
 use ACSEO\TypesenseBundle\Manager\CollectionManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 class CreateCommand extends Command
 {
@@ -24,6 +26,7 @@ class CreateCommand extends Command
     {
         $this
             ->setName(self::$defaultName)
+            ->addOption('indexes', null, InputOption::VALUE_OPTIONAL, 'The index(es) to repopulate. Comma separated values')
             ->setDescription('Create Typsenses indexes')
 
         ;
@@ -31,9 +34,25 @@ class CreateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $defs = $this->collectionManager->getCollectionDefinitions();
+        $io = new SymfonyStyle($input, $output);
 
-        foreach ($defs as $name => $def) {
+        $collectionDefinitions = $this->collectionManager->getCollectionDefinitions();
+        $indexes = (null !== $indexes = $input->getOption('indexes')) ? explode(',', $indexes) : \array_keys($collectionDefinitions);
+
+        foreach ($indexes as $index) {
+            if (!isset($collectionDefinitions[$index])) {
+                $io->error('Unable to find index "'.$index.'" in collection definition (available : '.implode(', ', array_keys($collectionDefinitions)).')');
+
+                return 2;
+            }
+        }
+
+        // filter collection definitions
+        $collectionDefinitions = array_filter($collectionDefinitions, function ($key) use ($indexes) {
+            return \in_array($key, $indexes, true);
+        }, ARRAY_FILTER_USE_KEY);
+
+        foreach ($collectionDefinitions as $name => $def) {
             $name = $def['name'];
             $typesenseName = $def['typesense_name'];
             try {


### PR DESCRIPTION
Pushed a new iteration for our DB index script. Here’s the quick rundown:

**Problem**: The old script wiped all indices on every config deployment. It was overkill, especially for large DBs, leading to avoidable downtime.

**Solution**: The script now diffs the new config against the current indices. Only updates what’s needed. Steps are:

**Why**: Reduces load and downtime. 

Check out the commit and hit me up with questions or concerns.