### PR TITLE
allow to use infix param

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -38,6 +38,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('name')->end()
                                         ->scalarNode('type')->end()
                                         ->booleanNode('facet')->end()
+                                        ->booleanNode('infix')->end()
                                         ->booleanNode('optional')->end()
                                     ->end()
                                 ->end()

--- a/src/Finder/TypesenseQuery.php
+++ b/src/Finder/TypesenseQuery.php
@@ -66,6 +66,14 @@ class TypesenseQuery
     }
 
     /**
+     * A list of fields that will be used for querying your results on. Separate multiple fields with a comma.
+     */
+    public function infix(string $infix): self
+    {
+        return $this->addParameter('infix', $infix);
+    }
+
+    /**
      * A list of fields that will be used for faceting your results on. Separate multiple fields with a comma.
      */
     public function facetBy(string $facetBy): self

--- a/tests/Unit/Finder/TypesenseQueryTest.php
+++ b/tests/Unit/Finder/TypesenseQueryTest.php
@@ -25,6 +25,7 @@ class TypesenseQueryTest extends TestCase
             ->prefix(false)
             ->filterBy('filter term')
             ->sortBy('sort term')
+            ->infix('off')
             ->facetBy('facet term')
             ->maxFacetValues(10)
             ->numTypos(0)
@@ -42,6 +43,7 @@ class TypesenseQueryTest extends TestCase
                 'prefix'                => false,
                 'filter_by'             => 'filter term',
                 'sort_by'               => 'sort term',
+                'infix'                 => 'off',
                 'facet_by'              => 'facet term',
                 'max_facet_values'      => 10,
                 'num_typos'             => 0,


### PR DESCRIPTION
**Why This Matters:**
Issue #89 highlighted the need for partial match capabilities. infix allows users to get search results with partial word matches, which is a solid boost to our search functionality.

**What's New:**

Added infix option to the bundle's config.
Updated the search method to pass the infix parameter when present.
**Impact:**
It enhances search flexibility without impacting existing configurations. It's optional and backward compatible.

Let's merge this if there're no blockers. Any thoughts or tests you want to run, let me know.