### PR TITLE
feat: allow to hydrate the result of rawQuery call

### DIFF
--- a/src/Finder/CollectionFinder.php
+++ b/src/Finder/CollectionFinder.php
@@ -33,6 +33,11 @@ class CollectionFinder implements CollectionFinderInterface
         return $this->hydrate($results);
     }
 
+    public function hydrateResponse(TypesenseResponse $response)
+    {
+        return $this->hydrate($response);
+    }
+
     private function hydrate($results)
     {
         $ids             = [];

--- a/src/Finder/CollectionFinderInterface.php
+++ b/src/Finder/CollectionFinderInterface.php
@@ -9,4 +9,6 @@ interface CollectionFinderInterface
     public function rawQuery(TypesenseQuery $query);
 
     public function query(TypesenseQuery $query);
+
+    public function hydrateResponse(TypesenseResponse $response);
 }


### PR DESCRIPTION
Hi,

Actually if we use `CollectionFinder::query`, we cannot access to Typesense response metada like `found`.

With this new `CollectionFinder::hydrateResponse`, we can first call `CollectionFinder::rawQuery` in order to access to metadata then call  the new method to hydrate the result.

Useful when using KnpPaginator for example: 

```php
class TypesenseQuerySubscriber implements EventSubscriberInterface
{
    public function items(ItemsEvent $event): void
    {
        // [...]
        
        $results = $finder->rawQuery($query);

        $event->count = $results->getFound();
        $event->items = $finder->hydrateResponse($results)->getResults();

        $event->stopPropagation();
    }
}