### PR TITLE
Update ACSEOTypesenseExtension.php

### DIFF
--- a/src/DependencyInjection/ACSEOTypesenseExtension.php
+++ b/src/DependencyInjection/ACSEOTypesenseExtension.php
@@ -33,7 +33,9 @@ class ACSEOTypesenseExtension extends Extension
      * @var array
      */
     private $parameters = [];
-
+    /**
+     * @return void
+     */
     public function load(array $configs, ContainerBuilder $container)
     {
         $configuration = new Configuration();
@@ -68,6 +70,7 @@ class ACSEOTypesenseExtension extends Extension
      * Loads the configured clients.
      *
      * @param ContainerBuilder $container A ContainerBuilder instance
+     * @return void
      */
     private function loadClient($config, ContainerBuilder $container)
     {
@@ -86,7 +89,7 @@ class ACSEOTypesenseExtension extends Extension
      *
      * @param array            $collections An array of collection configurations
      * @param ContainerBuilder $container   A ContainerBuilder instance
-     *
+     * @return void
      * @throws \InvalidArgumentException
      */
     private function loadCollections(array $collections, ContainerBuilder $container)


### PR DESCRIPTION
Suppress deprecated message :
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "ACSEO\TypesenseBundle\DependencyInjection\ACSEOTypesenseExtension" now to avoid errors or add an explicit @return annotation to suppress this message.