### PR TITLE
Avoid deprecation warning in PHP 8.4 for nullable parameters

### DIFF
--- a/src/Client/CollectionClient.php
+++ b/src/Client/CollectionClient.php
@@ -58,7 +58,7 @@ class CollectionClient
         return $this->client->collections->retrieve();
     }
 
-    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false, array $embed = null)
+    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false, array ?$embed = null)
     {
         if (!$this->client->isOperationnal()) {
             return null;

--- a/src/Client/CollectionClient.php
+++ b/src/Client/CollectionClient.php
@@ -58,7 +58,7 @@ class CollectionClient
         return $this->client->collections->retrieve();
     }
 
-    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false, array ?$embed = null)
+    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false, ?array $embed = null)
     {
         if (!$this->client->isOperationnal()) {
             return null;


### PR DESCRIPTION
This PR fixes a deprecation introduced in PHP 8.4 where implicitly nullable parameters are no longer allowed.
The $embed parameter was declared as array $embed = null but must be explicitly nullable as ?array $embed = null to prevent the following deprecation notice:

"Implicitly marking parameter $embed as nullable is deprecated, the explicit nullable type must be used instead."

This change ensures forward compatibility with PHP 8.4 and follows the stricter typing requirements introduced in PHP 8.4.