### PR TITLE
[Embed] feat: Add api_key and url parameters for custom embedding ser…

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,12 @@ acseo_typesense:
                         from:
                             - title
                             - description
-                        model_config: 
-                            model_name: ts/e5-small
+                        model_config:
+                            model_name: ts/e5-small  # Typesense Cloud model (requires Typesense Cloud)
+                            # For custom embedding services (Ollama, local models, etc.):
+                            # model_name: 'openai/your-model-name'
+                            # url: 'http://your-embedding-service:port'
+                            # api_key: 'your-api-key'  # Optional
             default_sorting_field: sortable_id       # Default sorting field. Must be int32 or float
             symbols_to_index: ['+']                  # Optional - You can add + to this list to make the word c++ indexable verbatim.
         users:
@@ -327,7 +331,7 @@ $commonParams = new TypesenseQuery()->addParameter('query_by', 'name');
 $response = $this->collectionClient->multisearch($searchRequests, $commonParams);
 ```
 
-## Cookbook 
+## Cookbook
 ----------------
 
 * [Use Typesense to make an autocomplete field](doc/cookbook/autocomplete.md)

--- a/src/Client/CollectionClient.php
+++ b/src/Client/CollectionClient.php
@@ -105,7 +105,7 @@ class CollectionClient
         return $this->client->collections->retrieve();
     }
 
-    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false, ?array $embed = null)
+    public function create($name, $fields, $defaultSortingField, array $tokenSeparators, array $symbolsToIndex, bool $enableNestedFields = false)
     {
         if (!$this->client->isOperationnal()) {
             return null;
@@ -119,10 +119,6 @@ class CollectionClient
             'symbols_to_index'      => $symbolsToIndex,
             'enable_nested_fields'  => $enableNestedFields,
         ];
-        
-        if ($embed) {
-            $options['embed'] = $embed;
-        }
 
         $this->client->collections->create($options);
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -52,6 +52,8 @@ class Configuration implements ConfigurationInterface
                                                 ->arrayNode('model_config')
                                                     ->children()
                                                         ->scalarNode('model_name')->isRequired()->end()
+                                                        ->scalarNode('api_key')->cannotBeEmpty()->end()
+                                                        ->scalarNode('url')->cannotBeEmpty()->end()
                                                     ->end()
                                                 ->end()
                                             ->end()

--- a/src/Manager/CollectionManager.php
+++ b/src/Manager/CollectionManager.php
@@ -79,8 +79,7 @@ class CollectionManager
             $definition['default_sorting_field'],
             $tokenSeparators,
             $symbolsToIndex,
-            $definition['enable_nested_fields'] ?? false,
-            $definition['embed'] ?? null
+            $definition['enable_nested_fields'] ?? false
         );
     }
 }

--- a/tests/Unit/DependencyInjection/fixtures/acseo_typesense.yml
+++ b/tests/Unit/DependencyInjection/fixtures/acseo_typesense.yml
@@ -36,10 +36,21 @@ acseo_typesense:
                 genres:
                     name: genres
                     type: collection                 # Convert ArrayCollection to array of strings
-                publishedAt: 
+                publishedAt:
                     name: publishedAt
                     type: datetime
                     optional: true                   # Declare field as optional
+                embeddings:
+                    name: embeddings
+                    type: float[]
+                    optional: true
+                    embed:
+                        from:
+                            - title
+                        model_config:
+                            model_name: 'openai/test-model'
+                            api_key: 'test-api-key'
+                            url: 'http://test-url:8080'
             default_sorting_field: sortable_id       # Default sorting field. Must be int32 or float
             finders: 
                 title_or_author:


### PR DESCRIPTION
…vices (#137)

* feat: Add api_key and url parameters for custom embedding services

Allows using OpenAI-compatible APIs (Ollama, custom models) instead of only Typesense Cloud models for embeddings.

* test: Add test case for custom embedding service configuration

Validates that api_key and url parameters are properly accepted in embed.model_config without throwing exceptions.

* fix: Remove invalid embed parameter at collection level

- Remove embed from collection config (only exists at field level)
- Update CollectionClient and CollectionManager accordingly
- Improve test coverage for embed field configuration

---------