### PR TITLE
Add Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,23 +12,25 @@
     "require": {
         "php": "^7.4||^8.0",
         "doctrine/orm": "^2.8 || ^3.2",
-        "symfony/framework-bundle": "^4.3|^5|^6.0|^7.0",
-        "symfony/console": "^4.3.4|^5|^6.0|^7.0",
+        "symfony/framework-bundle": "^4.3|^5|^6.0|^7.0|^8.0",
+        "symfony/console": "^4.3.4|^5|^6.0|^7.0|^8.0",
         "typesense/typesense-php": "^4.5",
         "php-http/curl-client": "^2.2",
         "monolog/monolog": "^2.3|^3.0",
-        "symfony/property-access": "^3.4|^4.3|^5|^6.0|^7.0",
-        "symfony/http-client": "^5.4|^6.2|^7.0"
+        "symfony/property-access": "^3.4|^4.3|^5|^6.0|^7.0|^8.0",
+        "symfony/http-client": "^5.4|^6.2|^7.0|^8.0"
     },
     "require-dev": {
         "symfony/phpunit-bridge": "^5.0|^6.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/yaml": "^3.4 || ^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^3.4 || ^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0",
         "dg/bypass-finals": "^1.9",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {
-        "psr-4": { "ACSEO\\TypesenseBundle\\": "src/" }
+        "psr-4": {
+            "ACSEO\\TypesenseBundle\\": "src/"
+        }
     },
     "autoload-dev": {
         "psr-4": {
@@ -37,8 +39,8 @@
     },
     "scripts": {
         "typesenseServer": [
-          "Composer\\Config::disableProcessTimeout",
-          "docker run -i -p 8108:8108 -v/tmp/typesense-server-data-1c/:/data typesense/typesense:27.1 --data-dir /data --api-key=123 --listen-port 8108 --enable-cors"
+            "Composer\\Config::disableProcessTimeout",
+            "docker run -i -p 8108:8108 -v/tmp/typesense-server-data-1c/:/data typesense/typesense:27.1 --data-dir /data --api-key=123 --listen-port 8108 --enable-cors"
         ]
     },
     "config": {


### PR DESCRIPTION
This PR adds Symfony 8 compatibility by updating the version constraints in `composer.json`.

### Changes

- `symfony/framework-bundle`: `^4.3|^5|^6.0|^7.0` → `^4.3|^5|^6.0|^7.0|^8.0`
- `symfony/console`: `^4.3.4|^5|^6.0|^7.0` → `^4.3.4|^5|^6.0|^7.0|^8.0`
- `symfony/property-access`: `^3.4|^4.3|^5|^6.0|^7.0` → `^3.4|^4.3|^5|^6.0|^7.0|^8.0`
- `symfony/http-client`: `^5.4|^6.2|^7.0` → `^5.4|^6.2|^7.0|^8.0`
- `symfony/yaml` (dev): `^3.4 || ^4.4 || ^5.4 || ^6.0` → `^3.4 || ^4.4 || ^5.4 || ^6.0 || ^7.0 || ^8.0`

Symfony 8 was released and this bundle currently blocks projects from upgrading. The codebase is already compatible — only the composer constraints need updating.